### PR TITLE
Add cosmoDC2 documentation

### DIFF
--- a/web/portal/templates/doc/cosmodc2.md
+++ b/web/portal/templates/doc/cosmodc2.md
@@ -1,0 +1,42 @@
+<!--- Do not delete this line, it is needed for jinja_markdown to render this page correctly -->
+
+## Accessing cosmoDC2
+
+If you use cosmoDC2 in your work, please cite [Korytov et al. (LSST DESC), ApJS, 245, 26 (2019)](https://ui.adsabs.harvard.edu/abs/2019ApJS..245...26K/abstract). In addition, if you use `GCRCatalogs` as described here to access cosmoDC2, please also cite [Mao et al. (LSST DESC), ApJS, 234, 36 (2018)](https://ui.adsabs.harvard.edu/abs/2018ApJS..234...36M/abstract).
+
+
+### Step 1: Download cosmoDC2 catalog files
+
+Follow [these instructions](download) to download "CosmoDC2 v1.1.4" data files.
+You can download the full data set and a subset of files.
+Note that the full catalog is partitioned into sky areas by healpixels and also by redshift ranges.
+
+
+### Step 2: Prepare `GCRCatalogs`
+
+To help you access the cosmoDC2 data, the LSST DESC has developed the `GCRCatalogs` Pyhton package. While there are detailed instructions and tutorials available or linked from the [GitHub repository of `GCRCatalogs`](https://github.com/LSSTDESC/gcr-catalogs), they generally assume that the user is a DESC member and is running the code on NERSC. Nevertheless, some simple customization can enable you to use  `GCRCatalogs` to access cosmoDC2 on your local machine.
+
+Follow [these instructions](install_gcr) to install `GCRCatalogs`.
+
+
+### Step 3: Load cosmoDC2 with GCRCatalogs
+
+```python
+import GCRCatalogs
+cat = GCRCatalogs.load_catalog("desc_cosmodc2")
+```
+
+### Step 4: Get familiar with GCRCatalogs and cosmoDC2
+
+There are many tutorial notebooks showing you how to use GCRCatalogs and how to play with the cosmoDC2 data.
+Note that if you see the tutorial notebooks load `cosmoDC2_v1.1.4_small` or `cosmoDC2_v1.1.4_image`,
+you will need to change the catalog name to `desc_cosmodc2`.
+
+Note that in some tutorials you may see instructions of loading other catalogs with `GCRCatalogs`. Those instructions will *not* work on your local machine. You will only be able to public DESC catalogs that you have downloaded to your machine.
+
+- [Basic usage of `GCRCatalogs`](https://nbviewer.jupyter.org/github/LSSTDESC/gcr-catalogs/blob/master/examples/GCRCatalogs%20Demo.ipynb)
+- [Tutorial: Redshift distributions](https://nbviewer.jupyter.org/github/LSSTDESC/DC2-analysis/blob/rendered/tutorials/extragalactic_gcr_redshift_dist.nbconvert.ipynb)
+- [Tutorial: Halo Occupation Distribution](https://nbviewer.jupyter.org/github/LSSTDESC/DC2-analysis/blob/rendered/tutorials/extragalactic_gcr_hod.nbconvert.ipynb)
+- [Tutorial: mass relations](https://nbviewer.jupyter.org/github/LSSTDESC/DC2-analysis/blob/rendered/tutorials/extragalactic_gcr_mass_relations.nbconvert.ipynb)
+- [Tutorial: cluster colors](https://nbviewer.jupyter.org/github/LSSTDESC/DC2-analysis/blob/rendered/tutorials/extragalactic_gcr_cluster_colors.nbconvert.ipynb)
+- [Tutorial: cluster members](https://nbviewer.jupyter.org/github/LSSTDESC/DC2-analysis/blob/rendered/tutorials/extragalactic_gcr_cluster_members.nbconvert.ipynb)

--- a/web/portal/templates/doc/getting_started.md
+++ b/web/portal/templates/doc/getting_started.md
@@ -2,10 +2,7 @@
 ### Getting Started
 
 * [How to Download data files]({{url_for('render_doc', doc_name='download')}})
-
 * [Globus Personal Connect]({{url_for('render_doc', doc_name='globus_personal')}})
-
 * [Installing `GCRCatalogs`]({{url_for('render_doc', doc_name='install_gcr')}})
-
 * [Accessing data files with `GCRCatalogs`]({{url_for('render_doc', doc_name='access_with_gcr')}})
-
+* [Using cosmoDC2]({{url_for('render_doc', doc_name='cosmodc2')}})


### PR DESCRIPTION
This PR adds cosmoDC2 documentation. The content is mostly copied from https://portal.nersc.gov/project/lsst/cosmoDC2/_README.html but with updated instrcutions or links to existing instructions in the repo. 

Fixes #6