### PR TITLE
Implement the proposed doc improvement from DC2-Public-Release

### DIFF
--- a/web/portal/templates/doc/access_with_gcr.md
+++ b/web/portal/templates/doc/access_with_gcr.md
@@ -1,27 +1,27 @@
 <!--- Do not delete this line, it is needed for jinja_markdown to render this page correctly -->
 ## Access Data Files with GCRCatalogs
 
-### Setting up `root_dir` for GCRCatalogs
-
-After you [downloaded the data files]({{url_for('render_doc', doc_name='download')}}) and [installed `GCRCatalogs`]({{url_for('render_doc', doc_name='install_gcr')}}),
-you need to tell `GCRCatalogs` where these downloaded files sit on your machine. 
-
-When you used Globus transfer, if you downloaded the files to `/path/to/the/download/directory`, then run in a terminal
-
-```bash
-python -m GCRCatalogs.user_config set root_dir /path/to/the/download/directory
-```
-
-Here `/path/to/the/download/directory` should contain the `lsstdesc-public` folder that Globus transfer creates. 
-If you have moved it, you should change `/path/to/the/download/directory` to the directory that contains the `lsstdesc-public` folder.
-Do not change the directory structure within `lsstdesc-public`. 
-
-You only need to set this once. 
-
 ### Checking that everything is ready
 
 You can use the following Python code to check if you have `GCRCatalogs` installed and `root_dir` correctly set.
-The lower two lines should print out the tracts that you have downloaded for Object and Truth tables, respectively.
+
+```python
+import GCRCatalogs
+GCRCatalogs.get_root_dir()
+```
+
+To see the list of public catalogs that may be available to you, run:
+
+```python
+GCRCatalogs.get_public_catalog_names()
+```
+
+Note that the above function returns the list of public catalogs that DESC has published,
+but it does not check if those catalog files exist on your machine.
+You will need to download them manually following [these instructions](download).
+
+For the DC2 Object and Truth tables specifically, you can use the following code to print out the tracts
+that you have downloaded.
 
 ```python
 import GCRCatalogs
@@ -31,5 +31,6 @@ print(GCRCatalogs.load_catalog('desc_dc2_run2.2i_dr6_truth').available_tracts)
 
 ### Following the notebooks to access data
 
-You can find examples of using `GCRCatalogs` in our [tutorial notebooks](https://github.com/LSSTDESC/DC2-Public-Release/tree/main/notebooks).
+You can find examples of using `GCRCatalogs` in our [tutorial notebooks](https://github.com/LSSTDESC/desc-data-portal/tree/main/notebooks).
 
+If you're planning to run the example notebooks and don't already have JupyterLab on your laptop, see [these instructions](https://jupyterlab.readthedocs.io/en/stable/getting_started/installation.html).

--- a/web/portal/templates/doc/install_gcr.md
+++ b/web/portal/templates/doc/install_gcr.md
@@ -1,5 +1,5 @@
 <!--- Do not delete this line, it is needed for jinja_markdown to render this page correctly -->
-# Install GCRCatalogs
+# Install and Configure `GCRCatalogs`
 
 You can install [`GCRCatalogs`](https://github.com/LSSTDESC/gcr-catalogs) with [conda](https://docs.conda.io/) or [pip](https://pip.pypa.io/),
 depending on your local Python environment.
@@ -26,7 +26,19 @@ To install, simply run
 pip install https://github.com/LSSTDESC/gcr-catalogs/archive/v1.2.0rc2.tar.gz#egg=GCRCatalogs[full]
 ```
 
-## Install JupyterLab (optional)
+### Configure: Setting up `root_dir` for GCRCatalogs
 
-If you're planning to run the example notebooks and don't already have JupyterLab on your laptop, see [these instructions](https://jupyterlab.readthedocs.io/en/stable/getting_started/installation.html).
+After you [downloaded the data files]({{url_for('render_doc', doc_name='download')}}) and [installed `GCRCatalogs`]({{url_for('render_doc', doc_name='install_gcr')}}),
+you need to tell `GCRCatalogs` where these downloaded files sit on your machine.
 
+When you used Globus transfer, if you downloaded the files to `/path/to/the/download/directory`, then run in a terminal
+
+```bash
+python -m GCRCatalogs.user_config set root_dir /path/to/the/download/directory
+```
+
+Here `/path/to/the/download/directory` should contain the `lsstdesc-public` folder that Globus transfer creates.
+If you have moved it, you should change `/path/to/the/download/directory` to the directory that contains the `lsstdesc-public` folder.
+Do not change the directory structure within `lsstdesc-public`.
+
+You only need to set this once.


### PR DESCRIPTION
This PR implements the proposed doc improvement from DC2-Public-Release (see https://github.com/LSSTDESC/DC2-Public-Release/pull/8/files)

I didn't implement the overview part since that page no longer exists in the portal site. 

Fixes #9