### PR TITLE
Add overview paragraph

### DIFF
--- a/web/portal/templates/doc/getting_started.md
+++ b/web/portal/templates/doc/getting_started.md
@@ -1,6 +1,14 @@
 
 ### Getting Started
 
+Start by downloading data files from the Portal. Note that the complete dataset is about 180 Gbytes; you may want to start with a subset. We recommend the sample subset required by the tutorial notebooks. At this point you may access the files directly using standard Parquet tools.
+
+Alternatively, for a higher-level interface, you may install and configure the Python package GCRCatalogs.
+
+In order to get some experience with the data we have provided a pair of Jupyter notebooks. GCRCatalogs is required in order to run them.
+
+#### Specifics
+
 * [How to Download data files]({{url_for('render_doc', doc_name='download')}})
 * [Globus Personal Connect]({{url_for('render_doc', doc_name='globus_personal')}})
 * [Installing `GCRCatalogs`]({{url_for('render_doc', doc_name='install_gcr')}})

--- a/web/portal/templates/doc/getting_started.md
+++ b/web/portal/templates/doc/getting_started.md
@@ -1,7 +1,7 @@
 
 ### Getting Started
 
-Start by downloading data files from the Portal. Note that the complete dataset is about 180 Gbytes; you may want to start with a subset. We recommend the sample subset required by the tutorial notebooks. At this point you may access the files directly using standard Parquet tools.
+Start by downloading data files from the Portal. Note that the complete DC2 dataset (Object and Truth Match) is about 180 Gbytes; you may want to start with a subset. We recommend the sample subset required by the tutorial notebooks. At this point you may access the files directly using standard Parquet tools.
 
 Alternatively, for a higher-level interface, you may install and configure the Python package GCRCatalogs.
 

--- a/web/portal/templates/home.jinja2
+++ b/web/portal/templates/home.jinja2
@@ -44,7 +44,7 @@
             <!-- <h3 class="h3 mb-3">Dark Energy Science Collaboration</h3> -->
 	    <p>Welcome to the LSSTDESC Data Portal.</p>
             {%if session.get('is_authenticated')%}
-            <p>Now that you are logged into Globus, click the Transfer menu item above to browse and download data.</p>
+            <p>Now that you are logged into Globus, you may click the Transfer menu item above to browse and download data.</p>
             <p>If you have questions, please see the "Getting Started" section below.</p>
             {%else%}
             <p>If you are new to Globus or have questions, please see the "Getting Started" section below. Otherwise, to download datasets, click Login above to authenticate into Globus using your organizational login or existing GlobusID. If needed, create a <a href="https://www.globusid.org/what" target="_blank">GlobusID</a> using the "Sign Up" link.</p>


### PR DESCRIPTION
I didn't change the text in home.jinja2 significantly because I see it distinguishes between users who are logged in or not, with useful information in both cases.  It could perhaps be shortened a bit by omitting the suggestion to look below, especially if we use a smaller font so that "below" is not very far.