### PR TITLE
Update home page and resource page

### DIFF
--- a/web/portal/templates/doc/getting_started.md
+++ b/web/portal/templates/doc/getting_started.md
@@ -6,13 +6,3 @@ Start by downloading data files from the Portal. Note that the complete DC2 data
 Alternatively, for a higher-level interface, you may install and configure the Python package GCRCatalogs.
 
 In order to get some experience with the data we have provided a pair of Jupyter notebooks. GCRCatalogs is required in order to run them.
-
-#### Specifics
-
-* [How to download data files]({{url_for('render_doc', doc_name='download')}})
-* [Globus Personal Connect]({{url_for('render_doc', doc_name='globus_personal')}})
-* [Installing `GCRCatalogs`]({{url_for('render_doc', doc_name='install_gcr')}})
-* [Accessing data files with `GCRCatalogs`]({{url_for('render_doc', doc_name='access_with_gcr')}})
-* [Using cosmoDC2]({{url_for('render_doc', doc_name='cosmodc2')}})
-* [References]({{url_for('render_doc', doc_name='references')}})
-* [Need Help?](https://github.com/LSSTDESC/desc-data-portal/discussions)

--- a/web/portal/templates/doc/getting_started.md
+++ b/web/portal/templates/doc/getting_started.md
@@ -1,9 +1,10 @@
 
 ### Getting Started
 
-* [How to Download data files]({{url_for('render_doc', doc_name='download')}})
+* [How to download data files]({{url_for('render_doc', doc_name='download')}})
 * [Globus Personal Connect]({{url_for('render_doc', doc_name='globus_personal')}})
 * [Installing `GCRCatalogs`]({{url_for('render_doc', doc_name='install_gcr')}})
 * [Accessing data files with `GCRCatalogs`]({{url_for('render_doc', doc_name='access_with_gcr')}})
 * [Using cosmoDC2]({{url_for('render_doc', doc_name='cosmodc2')}})
+* [References]({{url_for('render_doc', doc_name='references')}})
 * [Need Help?](https://github.com/LSSTDESC/desc-data-portal/discussions)

--- a/web/portal/templates/doc/menu.md
+++ b/web/portal/templates/doc/menu.md
@@ -1,0 +1,10 @@
+
+### Documentation
+
+* [How to download data files]({{url_for('render_doc', doc_name='download')}})
+* [Globus Personal Connect]({{url_for('render_doc', doc_name='globus_personal')}})
+* [Installing `GCRCatalogs`]({{url_for('render_doc', doc_name='install_gcr')}})
+* [Accessing data files with `GCRCatalogs`]({{url_for('render_doc', doc_name='access_with_gcr')}})
+* [Using cosmoDC2]({{url_for('render_doc', doc_name='cosmodc2')}})
+* [References]({{url_for('render_doc', doc_name='references')}})
+* [Need Help?](https://github.com/LSSTDESC/desc-data-portal/discussions)

--- a/web/portal/templates/doc/overview.md
+++ b/web/portal/templates/doc/overview.md
@@ -1,0 +1,1 @@
+<!--- Do not delete this line, it is needed for jinja_markdown to render this page correctly -->

--- a/web/portal/templates/doc/overview.md
+++ b/web/portal/templates/doc/overview.md
@@ -1,1 +1,0 @@
-<!--- Do not delete this line, it is needed for jinja_markdown to render this page correctly -->

--- a/web/portal/templates/doc/references.md
+++ b/web/portal/templates/doc/references.md
@@ -1,0 +1,25 @@
+
+## References
+
+
+### DC2 Simulated Sky Survey
+
+If you use a DESC DC2 Simulated Sky Survey data product in a publication,
+we ask that you cite the following publications.
+
+* [DESC DC2 Simulated Sky Survey Paper](https://ui.adsabs.harvard.edu/abs/2020arXiv201005926L/abstract)
+* [DESC DC2 Data Release Note](https://arxiv.org/abs/2101.00000)
+
+### CosmoDC2
+
+If you use the cosmoDC2 catalog in a publication,
+we ask that you cite the following publication.
+
+* [CosmoDC2 Paper](https://ui.adsabs.harvard.edu/abs/2019ApJS..245...26K/abstract)
+
+### Other References
+
+If you use the `GCRCatalogs` package in a publication,
+we ask that you cite the following publication.
+
+* [DESCQA Paper](https://ui.adsabs.harvard.edu/abs/2018ApJS..234...36M/abstract)

--- a/web/portal/templates/doc/resources.md
+++ b/web/portal/templates/doc/resources.md
@@ -1,8 +1,0 @@
-
-### Resources 
-
-* [DESC DC2 Note]()
-
-* [DESC DC2 Paper]()
-
-

--- a/web/portal/templates/home.jinja2
+++ b/web/portal/templates/home.jinja2
@@ -67,7 +67,7 @@
           <!--Grid column-->
           <div class="col-lg-6 col-md-12 px-4">
             {% markdown %}
-            {% include "doc/overview.md" %}
+            {% include "doc/getting_started.md" %}
             {% endmarkdown %}
           </div>
           <!--/Grid column-->
@@ -75,7 +75,7 @@
           <!--Grid column-->
           <div class="col-lg-6 col-md-12 px-4">
             {% markdown %}
-            {% include "doc/getting_started.md" %}
+            {% include "doc/menu.md" %}
             {% endmarkdown %}
           </div>
           <!--/Grid column-->

--- a/web/portal/templates/home.jinja2
+++ b/web/portal/templates/home.jinja2
@@ -12,7 +12,7 @@
         <div class="site-heading">
           <h1>LSSTDESC Data Portal</h1>
           <hr class="small">
-          <span class="subheading">Dark Energy Science Collaboration Public Data Access</span>
+          <span class="subheading">LSST Dark Energy Science Collaboration Public Data Access</span>
         </div>
       </div>
     </div>
@@ -23,40 +23,34 @@
 <main>
    <div class="container">
       <!--Section: Main info-->
-  <!--    <section class="mt-5 wow fadeIn"> -->
+      <section>
 
         <!--Grid row-->
         <div class="row">
 
           <!--Grid column-->
-          <div class="col-md-6 mb-4 px-4">
-
-  <!--          <img src="{{url_for('static',filename='img/logo.png') }}" class="img-fluid" alt="DESC Logo" width="553" height="370"> -->
-            <img src="{{url_for('static',filename='img/logo.png') }}" class="img-fluid" alt="DESC Logo" width="277" height="185">
-
+          <div class="col-sm-3 mb-4 px-4">
+            <p><img src="{{url_for('static',filename='img/logo.png') }}" class="img-fluid" alt="DESC Logo" width="100%"></p>
           </div>
           <!--Grid column-->
 
           <!--Grid column-->
-          <div class="col-md-6 mb-4 px-4">
-
-            <!-- Main heading -->
-            <!-- <h3 class="h3 mb-3">Dark Energy Science Collaboration</h3> -->
-	    <p>Welcome to the LSSTDESC Data Portal.</p>
+          <div class="col-sm-9 mb-4 px-4">
+      	    <p>Welcome to the <a href="https://lsstdesc.org">LSST DESC</a> Data Portal</p>
             {%if session.get('is_authenticated')%}
-            <p>Now that you are logged into Globus, click the Transfer menu item above to browse and download data.</p>
-            <p>If you have questions, please see the "Getting Started" section below.</p>
+            <p>You have logged into Globus. You can click <a href="{{url_for('transfer')}}">Transfer</a> in the top menu to browse and download data.</p>
+            <p>See the "Getting Started" section below for detailed instructions.</p>
             {%else%}
-            <p>If you are new to Globus or have questions, please see the "Getting Started" section below. Otherwise, to download datasets, click Login above to authenticate into Globus using your organizational login or existing GlobusID. If needed, create a <a href="https://www.globusid.org/what" target="_blank">GlobusID</a> using the "Sign Up" link.</p>
+            <p>If you are new to Globus or have questions, please see the "Getting Started" section below.
+            Otherwise, to download datasets, click <a href="{{url_for('login')}}">Login</a> above to authenticate into Globus using your organizational login or existing GlobusID. If needed, create a <a href="https://www.globusid.org/what" target="_blank">GlobusID</a> using the "Sign Up" link.</p>
             {%endif%}
-
           </div>
           <!--Grid column-->
 
         </div>
         <!--Grid row-->
 
-     <!-- </section> -->
+      </section>
       <!--Section: Main info-->
 
 
@@ -72,32 +66,17 @@
 
           <!--Grid column-->
           <div class="col-lg-6 col-md-12 px-4">
-
-            <!--First row-->
-            <div class="row pb-4">
-              <div class="col-10">
-                {% markdown %}
-                {% include "doc/getting_started.md" %}
-                {% endmarkdown %}
-              </div>
-            </div>
-            <!--/First row-->
-
+            {% markdown %}
+            {% include "doc/overview.md" %}
+            {% endmarkdown %}
           </div>
           <!--/Grid column-->
 
           <!--Grid column-->
           <div class="col-lg-6 col-md-12 px-4">
-            <!--Second row-->
-            <div class="row pb-4">
-              <div class="col-10">
-                {% markdown %}
-                {% include "doc/resources.md" %}
-                {% endmarkdown %}
-              </div>
-            </div>
-            <!--/Second row-->
-
+            {% markdown %}
+            {% include "doc/getting_started.md" %}
+            {% endmarkdown %}
           </div>
           <!--/Grid column-->
 
@@ -112,13 +91,13 @@
 
 
     <!--Section: acknowledgements -->
-  <!--  <section> -->
+    <section>
       <div class="col-12">
         <p class="grey-text small text-center pb-4">
           DESC acknowledges ongoing support from the US Department of Energy, IN2P3 (France), the STFC (United Kingdom), and the NSF and LSST Corporation (United States).
         </p>
       </div>
-    <!-- </section> -->
+    </section>
 
   </div>
   <!--Container-->


### PR DESCRIPTION
This PR fixes #32, fixes #30, and fixes #28. 

In this PR, I renamed the "Resources" page to "References", and put it as a link under the documentation menu. 

The space the "Resources" now can be used for overview text which @JoanneBogart is adding in #36. 
The overview text is under "Getting Started" (to appear in the left column), and the list of documentation pages will appear on the right column.

Several minor style tweaks to the home page. 