### PR TITLE
Update style for ul.alert

### DIFF
--- a/web/portal/static/css/style.css
+++ b/web/portal/static/css/style.css
@@ -8,6 +8,7 @@ body {
   font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: 20px;
   color: #404040;
+  webkit-tap-highlight-color: #4d75a8;
 }
 
 p {
@@ -485,10 +486,11 @@ img::-moz-selection {
   background: transparent;
 }
 
-body {
-  webkit-tap-highlight-color: #4d75a8;
-}
-
 p.task-detail {
   margin: 10px 0;
+}
+
+ul.alert {
+  list-style: none;
+  margin-top: 20px;
 }


### PR DESCRIPTION
This PR fixes #39 by removing the bullet point and add top margin for `ul.alert`.

I noticed in the stylesheet, style for `body` is specified in two different places. I've consolidated them.