### PR TITLE
Use example tracts in the notebook

### DIFF
--- a/notebooks/dc2/object_table_gcrcatalogs_intro.ipynb
+++ b/notebooks/dc2/object_table_gcrcatalogs_intro.ipynb
@@ -27,7 +27,7 @@
     "download the data files, install `GCRCatalogs`, and set up `root_dir` for `GCRCatalogs`.\n",
     "\n",
     "In this example notebook we will use up to 4 tracts: 3830, 3831, 4028, 4029. \n",
-    "If you have downloaded the example set from the Data Portal, it has included these four tracts, so you are all set. \n",
+    "The example set from the Data Portal includes these four tracts, so If you have downloaded it you are all set. \n",
     "If you have downloaded different tracts, remember to change the tract number(s) used in `tract_filter` when you run this notebook."
    ]
   },

--- a/notebooks/dc2/object_table_gcrcatalogs_intro.ipynb
+++ b/notebooks/dc2/object_table_gcrcatalogs_intro.ipynb
@@ -18,14 +18,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Before you start\n",
     "\n",
     "Make sure you have followed the instructions on the [DESC Data Portal](https://lsstdesc-portal.nersc.gov/) to \n",
-    "download the data files, install `GCRCatalogs`, and set up `root_dir` for `GCRCatalogs`."
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+    "download the data files, install `GCRCatalogs`, and set up `root_dir` for `GCRCatalogs`.\n",
+    "\n",
+    "In this example notebook we will use up to 4 tracts: 3830, 3831, 4028, 4029. \n",
+    "If you have downloaded the example set from the Data Portal, it has included these four tracts, so you are all set. \n",
+    "If you have downloaded different tracts, remember to change the tract number(s) used in `tract_filter` when you run this notebook."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -202,9 +206,9 @@
     "There are three ways to call `tract_filter`\n",
     "\n",
     "```python\n",
-    "tract_filter(4225)  # select one tract, 4225\n",
+    "tract_filter(3830)  # select one tract, 3830\n",
     "tract_filter(4200, 4300)  # select all tracts between 4200 and 4300 (inclusive on both ends!)\n",
-    "tract_filter([4225, 4228, 4230])  # select the tracts specified in the list\n",
+    "tract_filter([3830, 3831, 4028, 4029])  # select the tracts specified in the list\n",
     "```\n",
     "\n",
     "You can then directly use the returns in the `native_filters` argument of `get_quantities`. Note that these tract filters will select on matched tracts, but will *not* warn or raise errors if a wanted tract is not available. \n",
@@ -227,7 +231,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tract_filter(2900, 3000).filter({\"tract\": np.array(obj_cat.available_tracts)})"
+    "tract_filter(3000, 4000).filter({\"tract\": np.array(obj_cat.available_tracts)})"
    ]
   },
   {
@@ -245,7 +249,7 @@
     "\n",
     "You can then directly use the returns in the `filters` argument  of `get_quantities`.\n",
     "\n",
-    "Now let's look at an example! We would like to retrieve the coordinates (ra, dec) of all objects in the tracts 4225, 4226, and 4430, and apply a down-sampling fraction of 1%. "
+    "Now let's look at an example! We would like to retrieve the coordinates (ra, dec) of all objects in 4 tracts: 3830, 3831, 4028, 4029, and apply a down-sampling fraction of 1%. "
    ]
   },
   {
@@ -255,10 +259,10 @@
    "outputs": [],
    "source": [
     "data = obj_cat.get_quantities(\n",
-    "    quantities=['ra', 'dec'],                            # columns we want to load, \n",
-    "    filters=[sample_filter(0.01)],                       # down sample at 1%\n",
-    "    native_filters=[tract_filter([4225, 4226, 4430])],   # select three tracts\n",
-    "    return_iterator=False,                               # concatenate data across tracts \n",
+    "    quantities=['ra', 'dec'],                                # columns we want to load, \n",
+    "    filters=[sample_filter(0.01)],                           # down sample at 1%\n",
+    "    native_filters=[tract_filter([3830, 3831, 4028, 4029])], # select four tracts\n",
+    "    return_iterator=False,                                   # concatenate data across tracts \n",
     ")\n",
     "\n",
     "# Plot a 2d histogram of sources \n",
@@ -333,8 +337,8 @@
     "\n",
     "Concatenating data across tracts is convenient but costs more memory. If your analysis allows, a more memory efficient approach would be to reduce the data for one tract, stored the reduced product, and repeat for other tracts. The `return_iterator` option will turn `get_quantities` into a generator function (i.e., can used in a for loop directly, like `range`), making it easy for users to iterate over tracts.\n",
     "\n",
-    "In the example below, we will loop over ten tracts that have the same RA range (you can look up tract numbers in Figure 1 of the release note).\n",
-    "For each tract, we will load 0.1% of the objects and put them on a scatter plot. We will also print out a message to see where we are in the for loop. When the loop finishes, we should see a beautiful and colorful strip!"
+    "In the example below, we will loop over the four example tracts (you can look up tract numbers in Figure 1 of the release note).\n",
+    "For each tract, we will load 0.1% of the objects and put them on a scatter plot. We will also print out a message to see where we are in the for loop. When the loop finishes, we should see a beautiful and colorful map, as each tract will be plotted in a different color!"
    ]
   },
   {
@@ -345,11 +349,11 @@
    "source": [
     "fig, ax = plt.subplots(figsize=(10,5), dpi=100)\n",
     "\n",
-    "for data in obj_cat.get_quantities(                     # note how we use `get_quantities` directly in a for loop\n",
-    "    quantities=['ra', 'dec', 'tract'],                  # columns we want to load, \n",
-    "    filters=[sample_filter(0.001)],                     # down sample at 0.1%\n",
-    "    native_filters=[tract_filter(3075, 3084)],          # select 10 tracts [3075, 3084] inclusive on ends\n",
-    "    return_iterator=True,                               # return an iterator that iterates over tracts\n",
+    "for data in obj_cat.get_quantities(                           # note how we use `get_quantities` directly in a for loop\n",
+    "    quantities=['ra', 'dec', 'tract'],                        # columns we want to load, \n",
+    "    filters=[sample_filter(0.001)],                           # down sample at 0.1%\n",
+    "    native_filters=[tract_filter([3830, 3831, 4028, 4029])],  # select 4 tracts\n",
+    "    return_iterator=True,                                     # return an iterator that iterates over tracts\n",
     "):\n",
     "    print(\"Plotting data from tract\", data[\"tract\"][0])  # print out which tract is current being plotted\n",
     "    ax.scatter(data['ra'], data['dec'], s=1, label=str(data[\"tract\"][0]));\n",
@@ -465,7 +469,7 @@
     "for data in obj_cat.get_quantities(\n",
     "    quantities=['mag_g_cModel', 'mag_r_cModel'],                            # columns we want to load, \n",
     "    filters=[sample_filter(0.1), clean, is_extended, bright_g | bright_r],  # filters we want, including the sampler\n",
-    "    native_filters=[tract_filter([4225, 4226, 4430])],                      # select three tracts\n",
+    "    native_filters=[tract_filter([3830, 3831, 4028, 4029])],                # select four tracts\n",
     "    return_iterator=True,                                                   # return an iterator\n",
     "):\n",
     "    gr = data[\"mag_g_cModel\"] - data[\"mag_r_cModel\"]\n",
@@ -629,13 +633,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3.8.6 64-bit ('base': conda)",
-   "metadata": {
-    "interpreter": {
-     "hash": "9c54e8edd505ba0c12578c8976d22821e1092c9eec5194059a76e3a4e896bf91"
-    }
-   }
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -647,7 +647,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6-final"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/notebooks/dc2/truth_match_table.ipynb
+++ b/notebooks/dc2/truth_match_table.ipynb
@@ -28,7 +28,7 @@
     "download the data files, install `GCRCatalogs`, and set up `root_dir` for `GCRCatalogs`.\n",
     "\n",
     "In this example notebook we will only use tract 3830. \n",
-    "If you have downloaded the example set from the Data Portal, it has included this tract, so you are all set. \n",
+    "The example set from the Data Portal includes this tract, so if you have downloaded that set you are ready to go. \n" 
     "If you have downloaded different tracts, remember to change the tract number used in `tract_filter` when you run this notebook."
    ]
   },

--- a/notebooks/dc2/truth_match_table.ipynb
+++ b/notebooks/dc2/truth_match_table.ipynb
@@ -19,14 +19,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Before you start\n",
     "\n",
     "Make sure you have followed the instructions on the [DESC Data Portal](https://lsstdesc-portal.nersc.gov/) to \n",
-    "download the data files, install `GCRCatalogs`, and set up `root_dir` for `GCRCatalogs`."
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+    "download the data files, install `GCRCatalogs`, and set up `root_dir` for `GCRCatalogs`.\n",
+    "\n",
+    "In this example notebook we will only use tract 3830. \n",
+    "If you have downloaded the example set from the Data Portal, it has included this tract, so you are all set. \n",
+    "If you have downloaded different tracts, remember to change the tract number used in `tract_filter` when you run this notebook."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -176,6 +180,15 @@
     "\n",
     "additional_cols_in_match = set(match_cat.list_all_quantities()).difference(object_cat.list_all_quantities())\n",
     "set(col[:-6] if col.endswith(\"_truth\") else col for col in additional_cols_in_match) == set(truth_cat.list_all_quantities())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A side note: you may also notice that there are `cosmodc2_hp` and `cosmodc2_id` columns in the Truth Table. \n",
+    "These columns allow you to further match the galaxy truth entries to the [cosmoDC2 catalog](https://ui.adsabs.harvard.edu/abs/2019ApJS..245...26K).\n",
+    "We will not cover cosmoDC2 in this notebook, but you can find more information, including how to obtain the data, on [our Data Portal](https://lsstdesc-portal.nersc.gov/doc/cosmodc2)."
    ]
   },
   {
@@ -473,9 +486,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "desc-python-bleed",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "desc-python-bleed"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -487,7 +500,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.11"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR updates the example notebooks to use the example tract set: 3830, 3831, 4028, 4029. 

In the truth notebook, I also added a note about cosmoDC2 as a way to advertise it for those who are interested. 

This PR fixes #8.