### PR TITLE
fix Internal Server Error on Browse Dataset page when choosing no files

### DIFF
--- a/web/portal/templates/browse.jinja2
+++ b/web/portal/templates/browse.jinja2
@@ -35,7 +35,7 @@
 
 
     <div class="form-wrapper">
-      <form class="form-inline" role="form" action="{{url_for('browse')}}" method="post">
+      <form class="form-inline" role="form" action="{{url_for('browse', dataset_id=myid)}}" method="post">
 
         <div class="row">
           <div class="col-md-12">

--- a/web/portal/views.py
+++ b/web/portal/views.py
@@ -265,7 +265,7 @@ def browse(dataset_id=None, endpoint_id=None, endpoint_path=None):
     if request.method == 'POST':
         if not request.form.get('file'):
             flash('Please select at least one file.')
-            return redirect(url_for('browse'))
+            return redirect(url_for('browse', dataset_id=dataset_id))
 
         params = {
             'method': 'POST',


### PR DESCRIPTION
Fixes #43 
Now deployed on the dev portal.  You can test it by visiting any Browse Dataset page, don't select any files and click Transfer.  You can see the error by doing the same thing on the production portal.