### PR TITLE
Provide ability to download example subset of datasets

### DIFF
--- a/web/portal/data/datasets.json
+++ b/web/portal/data/datasets.json
@@ -3,21 +3,27 @@
         "name": "DC2 Truth Match dr6 v1",
         "id": "7b50d9a5-3412-4c60-81bb-113ba7f519fa",
         "path": "lsstdesc-public/dc2/run2.2i-dr6-v1/truth_match",
-        "size": "63 GB"
+        "size": "63 GB",
+        "example": ["truth_tract3830.parquet", "truth_tract3831.parquet", "truth_tract4028.parquet", "truth_tract4029.parquet"],
+        "exsize": "1.6 GB"
     },
 
     {
         "name": "DC2 Object DPDD dr6 v1",
         "id": "11767c28-e6c8-4901-92de-3e3d7502c7d4",
         "path": "lsstdesc-public/dc2/run2.2i-dr6-v1/object_dpdd",
-        "size": "118 GB"
+        "size": "118 GB",
+        "example": ["object_dpdd_tract3830.parquet", "object_dpdd_tract3831.parquet", "object_dpdd_tract4028.parquet", "object_dpdd_tract4029.parquet"],
+        "exsize": "3.6 GB"
     },
 
     {
         "name": "CosmoDC2 v1.1.4",
         "id": "3f93a2d4-65e9-4598-bd4c-a864cae2a195",
         "path": "lsstdesc-public/dc2/cosmoDC2_v1.1.4",
-        "size": "5.2 TB"
+        "size": "5.2 TB",
+        "example": ["z_0_1.step_all.healpix_9685.hdf5", "z_1_2.step_all.healpix_9685.hdf5", "z_2_3.step_all.healpix_9685.hdf5"],
+        "exsize": "40.6 GB"
     }
 
 ]

--- a/web/portal/templates/browse.jinja2
+++ b/web/portal/templates/browse.jinja2
@@ -33,7 +33,7 @@
   </p>
   <p class="grey-text small text-center pb-4">
     Choose the files you wish to download and click the Transfer button at the bottom of the page <strong>or</strong>
-  <a href="{{url_for('example', dataset_id=myid)}}" class="btn btn-info btn-sm">Get {{exsize}} Example Dataset</a>  
+  <a href="{{url_for('example', dataset_id=myid)}}" class="btn btn-info btn-sm">Get an {{exsize}} Example Subset</a>  
   </p>
 
 
@@ -61,7 +61,7 @@
                         {{file.name}}
                       {%endif%}
                     </td>
-                    <td class="col-md-1 text-right">{{file.size}}</td>
+                    <td class="col-md-1 text-right">{{file.size|filesizeformat}}</td>
                     <td class="col-md-1 text-center">
                       <input type="checkbox" name="file" value="{{file.name}}">
                       <input type="hidden" name="path" value="{{mypath}}">

--- a/web/portal/templates/browse.jinja2
+++ b/web/portal/templates/browse.jinja2
@@ -28,9 +28,12 @@
       Webapp</a>.
     {%endif%}
 -->
+
+
   </p>
   <p class="grey-text small text-center pb-4">
-    Choose the files you wish to download and click the Transfer button at the bottom of the page.
+    Choose the files you wish to download and click the Transfer button at the bottom of the page <strong>or</strong>
+  <a href="{{url_for('example', dataset_id=myid)}}" class="btn btn-info btn-sm">Get {{exsize}} Example Dataset</a>  
   </p>
 
 


### PR DESCRIPTION
Addresses a main part of #1 but not entirely in the way that was requested:
_In the “Browse Dataset” view, is there a way to add a “Select an example subset” button, which when clicked on, will check say 4 tracts that we use in the notebooks_ 
On the dev portal, when you visit the Browse Dataset view for any dataset, there is a new button which provides an option to transfer a predefined subset of the dataset being viewed.  Clicking the button does not cause the checkboxes to be checked, rather the transfer is initiated. 
This achieves the desired outcome, but doesn't allow a user to select additional files for download.  Is this ok? Well.. I'll put it this way, I don't see a good clean way yet to just check the checkboxes for the subset of files by communicating that information to the template.
