### PR TITLE
Update GCRCatalogs installation instructions to use stable v1.2.0

### DIFF
--- a/web/portal/templates/doc/install_gcr.md
+++ b/web/portal/templates/doc/install_gcr.md
@@ -12,28 +12,13 @@ Before installation, you may want to create a new conda environment.
 If you do,
 [see instructions here](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html).
 
-`GCRCatalogs` is available on [conda-forge](https://conda-forge.org/).
-To check if you are ready to obtain packages from conda-forge,
-run the following command and see if "conda-forge" appears in the output.
-
-```bash
-conda config --show channels
-```
-
-If you do _not_ see "conda-forge", you can add it by running:
-
-```bash
-conda config --add channels conda-forge
-conda config --set channel_priority strict
-```
-
 #### Install
 
+`GCRCatalogs` is available on [conda-forge](https://conda-forge.org/).
 To install `GCRCatalogs` with conda, run
 
-<!-- Remove "-c conda-forge/label/lsstdesc-gcr-catalogs_rc" from below when v1.2.0 is ready -->
 ```bash
-conda install lsstdesc-gcr-catalogs -c conda-forge/label/lsstdesc-gcr-catalogs_rc
+conda install -c conda-forge lsstdesc-gcr-catalogs
 ```
 
 ### Install with pip
@@ -44,8 +29,8 @@ Before installation, you may want to create a new virtual environment.
 If you do,
 [see instructions here](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment).
 
-You may want to first install `wheel`, 
-which will allow pip to fetch pre-built binary files. 
+You may want to first install `wheel`,
+which will allow pip to fetch pre-built binary files.
 To install `wheel`, run
 
 ```bash
@@ -56,9 +41,8 @@ pip install wheel  # optional
 
 To install `GCRCatalogs` with pip, run
 
-<!-- Change "v1.2.0rc2" to "v1.2.0" below when v1.2.0 is ready -->
 ```bash
-pip install https://github.com/LSSTDESC/gcr-catalogs/archive/v1.2.0rc2.tar.gz#egg=GCRCatalogs[full]
+pip install https://github.com/LSSTDESC/gcr-catalogs/archive/v1.2.0.tar.gz#egg=GCRCatalogs[full]
 ```
 
 ### Configure: Setting up `root_dir` for GCRCatalogs

--- a/web/portal/templates/doc/install_gcr.md
+++ b/web/portal/templates/doc/install_gcr.md
@@ -12,9 +12,15 @@ Before installation, you may want to create a new conda environment.
 If you do,
 [see instructions here](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html).
 
+`GCRCatalogs` is available on [conda-forge](https://conda-forge.org/), not on conda's "defaults" channel. 
+If you are using the "defaults" channel (for example, if you haven't heard of conda-forge),
+you can still install `GCRCatalogs` directly using the instruction below.
+However, please consider switching to the conda-forge channel; 
+see [instructions](https://conda-forge.org/docs/user/introduction.html#how-can-i-install-packages-from-conda-forge) 
+and [why](https://conda-forge.org/docs/user/tipsandtricks.html#using-multiple-channels).
+
 #### Install
 
-`GCRCatalogs` is available on [conda-forge](https://conda-forge.org/).
 To install `GCRCatalogs` with conda, run
 
 ```bash


### PR DESCRIPTION
Fixes #42

I actually decide to remove the conda-forge channel instructions because on my machine, where I used miniforge and has conda-forge already, the instructions actually added default channel for me, which is not great.. 

If anyone has insight that's welcome. But for now I believe adding `-c conda-forge` to `conda install` would work in both cases. 