### PR TITLE
Improve documentation navigation / dataset doc content

### DIFF
--- a/web/portal/data/datasets.json
+++ b/web/portal/data/datasets.json
@@ -4,7 +4,8 @@
         "id": "7b50d9a5-3412-4c60-81bb-113ba7f519fa",
         "path": "lsstdesc-public/dc2/run2.2i-dr6-v1/truth_match",
         "size": "63 GB",
-        "example": ["truth_tract3830.parquet", "truth_tract3831.parquet", "truth_tract4028.parquet", "truth_tract4029.parquet"]
+        "example": ["truth_tract3830.parquet", "truth_tract3831.parquet", "truth_tract4028.parquet", "truth_tract4029.parquet"],
+        "doc_name": "dc2_sim_sky_survey"
     },
 
     {
@@ -12,7 +13,8 @@
         "id": "11767c28-e6c8-4901-92de-3e3d7502c7d4",
         "path": "lsstdesc-public/dc2/run2.2i-dr6-v1/object_dpdd",
         "size": "118 GB",
-        "example": ["object_dpdd_tract3830.parquet", "object_dpdd_tract3831.parquet", "object_dpdd_tract4028.parquet", "object_dpdd_tract4029.parquet"]
+        "example": ["object_dpdd_tract3830.parquet", "object_dpdd_tract3831.parquet", "object_dpdd_tract4028.parquet", "object_dpdd_tract4029.parquet"],
+        "doc_name": "dc2_sim_sky_survey"
     },
 
     {
@@ -20,7 +22,8 @@
         "id": "3f93a2d4-65e9-4598-bd4c-a864cae2a195",
         "path": "lsstdesc-public/dc2/cosmoDC2_v1.1.4",
         "size": "5.2 TB",
-        "example": ["z_0_1.step_all.healpix_9685.hdf5", "z_1_2.step_all.healpix_9685.hdf5", "z_2_3.step_all.healpix_9685.hdf5"]
+        "example": ["z_0_1.step_all.healpix_9685.hdf5", "z_1_2.step_all.healpix_9685.hdf5", "z_2_3.step_all.healpix_9685.hdf5"],
+        "doc_name": "cosmodc2"
     }
 
 ]

--- a/web/portal/templates/browse.jinja2
+++ b/web/portal/templates/browse.jinja2
@@ -14,6 +14,7 @@
 
   <p>
     Displaying files in {{target}} <strong>{{description}}</strong>.
+    <a href="{{url_for('render_doc', doc_name=dataset['doc_name'])}}">Learn more about this data set.</a>
   </p>
 
   <p>

--- a/web/portal/templates/browse.jinja2
+++ b/web/portal/templates/browse.jinja2
@@ -14,7 +14,7 @@
 
   <p>
     Displaying files in {{target}} <strong>{{description}}</strong>.
-    <a href="{{url_for('render_doc', doc_name=dataset['doc_name'])}}">Learn more about this data set.</a>
+    <a href="{{url_for('render_doc', doc_name=doc_name)}}">Learn more about this data set.</a>
   </p>
 
   <p>

--- a/web/portal/templates/doc/cosmodc2.md
+++ b/web/portal/templates/doc/cosmodc2.md
@@ -1,20 +1,34 @@
 <!--- Do not delete this line, it is needed for jinja_markdown to render this page correctly -->
+## CosmoDC2
 
-## Accessing cosmoDC2
+CosmoDC2 is a large synthetic galaxy catalog designed to support precision dark energy science with LSST,
+covering 440 sq. deg. of sky area to a redshift of z = 3, with a magnitude depth of 28 in the r band.
+A wide range of galaxy properties are available in cosmoDC2.
+To learn more about cosmoDC2, please see
 
-If you use cosmoDC2 in your work, please cite [Korytov et al. (LSST DESC), ApJS, 245, 26 (2019)](https://ui.adsabs.harvard.edu/abs/2019ApJS..245...26K/abstract). In addition, if you use `GCRCatalogs` as described here to access cosmoDC2, please also cite [Mao et al. (LSST DESC), ApJS, 234, 36 (2018)](https://ui.adsabs.harvard.edu/abs/2018ApJS..234...36M/abstract).
+- [Korytov et al. (LSST DESC), ApJS, 245, 26 (2019)](https://ui.adsabs.harvard.edu/abs/2019ApJS..245...26K/abstract).
 
+If you use cosmoDC2 in your work, we ask that you cite the publication above.
 
 ### Step 1: Download cosmoDC2 catalog files
 
 Follow [these instructions](download) to download "CosmoDC2 v1.1.4" data files.
 You can download the full data set or, if space is at a premium, a recommended subset of files.
-Note that the full catalog is partitioned into sky areas by healpixels and also by redshift ranges.
+The data files you downloaded are in HDF5 format, partitioned into sky areas (by healpixels) and redshift ranges.
+The data schema can be found [here](
+https://github.com/LSSTDESC/gcr-catalogs/blob/master/GCRCatalogs/SCHEMA.md#extragalactic-catalogs).
 
+While you can access these files by standard tools, we recommend that you use `GCRCatalogs` to access the catalog
+because some quantities described in the [cosmoDC2 schema](
+https://github.com/LSSTDESC/gcr-catalogs/blob/master/GCRCatalogs/SCHEMA.md#extragalactic-catalogs)
+are only available when you access with `GCRCatalogs`, but not in the raw files.
 
 ### Step 2: Prepare `GCRCatalogs`
 
 See [these instructions](install_gcr) to install and configure `GCRCatalogs`.
+
+If you use `GCRCatalogs` as described here to access cosmoDC2, please also cite
+[Mao et al. (LSST DESC), ApJS, 234, 36 (2018)](https://ui.adsabs.harvard.edu/abs/2018ApJS..234...36M/abstract).
 
 ### Step 3: Load cosmoDC2 with GCRCatalogs
 

--- a/web/portal/templates/doc/cosmodc2.md
+++ b/web/portal/templates/doc/cosmodc2.md
@@ -1,4 +1,3 @@
-<!--- Do not delete this line, it is needed for jinja_markdown to render this page correctly -->
 ## CosmoDC2
 
 CosmoDC2 is a large synthetic galaxy catalog designed to support precision dark energy science with LSST,

--- a/web/portal/templates/doc/cosmodc2.md
+++ b/web/portal/templates/doc/cosmodc2.md
@@ -8,6 +8,7 @@ To learn more about cosmoDC2, please see
 
 - [Korytov et al. (LSST DESC), ApJS, 245, 26 (2019)](https://ui.adsabs.harvard.edu/abs/2019ApJS..245...26K/abstract).
 
+Follow the steps below to access cosmoDC2.
 If you use cosmoDC2 in your work, we ask that you cite the publication above.
 
 ### Step 1: Download cosmoDC2 catalog files

--- a/web/portal/templates/doc/dc2_sim_sky_survey.md
+++ b/web/portal/templates/doc/dc2_sim_sky_survey.md
@@ -1,4 +1,3 @@
-<!--- Do not delete this line, it is needed for jinja_markdown to render this page correctly -->
 ## DC2 Simulated Sky Survey
 
 The DC2 Simulated Sky Survey is a 300-sq-deq simulated survey

--- a/web/portal/templates/doc/dc2_sim_sky_survey.md
+++ b/web/portal/templates/doc/dc2_sim_sky_survey.md
@@ -1,21 +1,37 @@
 <!--- Do not delete this line, it is needed for jinja_markdown to render this page correctly -->
-## Accessing the DC2 Simulated Sky Survey
+## DC2 Simulated Sky Survey
 
-If you use the DC2 Simulated Sky Survey in your work, we ask that you cite the following publications.
+The DC2 Simulated Sky Survey is a 300-sq-deq simulated survey
+in six optical bands with observations following a reference LSST observing cadence.
 
-* [DESC DC2 Simulated Sky Survey Paper](https://ui.adsabs.harvard.edu/abs/2020arXiv201005926L/abstract)
-* [DESC DC2 Data Release Note](https://arxiv.org/abs/2101.04855)
+To learn more about the DC2 Simulated Sky Survey, you can read:
 
-In addition, if you use `GCRCatalogs` to access the data, please also cite [Mao et al. (LSST DESC), ApJS, 234, 36 (2018)](https://ui.adsabs.harvard.edu/abs/2018ApJS..234...36M/abstract).
+* [DESC DC2 Simulated Sky Survey Paper](https://ui.adsabs.harvard.edu/abs/2020arXiv201005926L/abstract):
+  a comprehensive description about the DC2 Simulated Sky Survey, including design choices and production details.
+* [DESC DC2 Data Release Note](https://arxiv.org/abs/2101.04855):
+  a brief note about the released dataset, including data file format, data partition scheme, and schema tables.
+
+If you use the DC2 Simulated Sky Survey in your work, we ask that you cite both publications above.
 
 ### Step 1: Download the catalog files
 
-Follow [these instructions](download) to download dpdd object or truth match data files from the DC2 Simulated Sky Survey.
+Follow [these instructions](download) to download "Object DPDD" or "Truth Match" data files from the DC2 Simulated Sky Survey.
 You can download the full data set or, if space is at a premium, a recommended subset of files.
+
+The data files you downloaded are in Parquet format, partitioned into sky regions
+(see Sec. 4.1 of the [Release Note](https://arxiv.org/abs/2101.04855) for details).
+You can access these files by standard tools that read Parquet format.
+We additionally provide a high-level Python package `GCRCatalogs` to facilitate easy access.
+
+Note that on some very old (e.g., older than 10 years) machines, reading Parquet files may be difficult.
+If that is a problem for you, please [let us know](https://github.com/LSSTDESC/desc-data-portal/discussions).
 
 ### Step 2: Prepare `GCRCatalogs`
 
 See [these instructions](install_gcr) to install and configure `GCRCatalogs`.
+
+If you use `GCRCatalogs` to access the data, please also cite
+[Mao et al. (LSST DESC), ApJS, 234, 36 (2018)](https://ui.adsabs.harvard.edu/abs/2018ApJS..234...36M/abstract).
 
 ### Step 3: Verify access to the data
 
@@ -27,7 +43,7 @@ print(GCRCatalogs.load_catalog('desc_dc2_run2.2i_dr6_object').available_tracts)
 print(GCRCatalogs.load_catalog('desc_dc2_run2.2i_dr6_truth').available_tracts)
 ```
 
-### Following the notebooks to access data
+### Step 4: Follow the notebooks to access data
 
 You can find examples of using `GCRCatalogs` in our [tutorial notebooks](https://github.com/LSSTDESC/desc-data-portal/tree/main/notebooks).
 

--- a/web/portal/templates/doc/dc2_sim_sky_survey.md
+++ b/web/portal/templates/doc/dc2_sim_sky_survey.md
@@ -11,6 +11,7 @@ To learn more about the DC2 Simulated Sky Survey, you can read:
 * [DESC DC2 Data Release Note](https://arxiv.org/abs/2101.04855):
   a brief note about the released dataset, including data file format, data partition scheme, and schema tables.
 
+Follow the steps below to access DC2 Simulated Sky Survey.
 If you use the DC2 Simulated Sky Survey in your work, we ask that you cite both publications above.
 
 ### Step 1: Download the catalog files

--- a/web/portal/templates/doc/download.md
+++ b/web/portal/templates/doc/download.md
@@ -1,4 +1,3 @@
-<!--- Do not delete this line, it is needed for jinja_markdown to render this page correctly -->
 ## How To Download Data
 
 The [LSSTDESC Data Portal](https://lsstdesc-portal.nersc.gov/) allows anyone to transfer the DC2 Public Release data using Globus.

--- a/web/portal/templates/doc/getting_started.md
+++ b/web/portal/templates/doc/getting_started.md
@@ -1,4 +1,3 @@
-
 ### Getting Started
 
 Start by downloading data files from the Portal. Note that the complete DC2 dataset (Object and Truth Match) is about 180 Gbytes and cosmoDC2 is over 5 Tbytes; you may want to start with a subset. We recommend the sample subset available from the Portal. Once downloaded, you may access the files directly using standard tools for the dataset file type.

--- a/web/portal/templates/doc/globus_personal.md
+++ b/web/portal/templates/doc/globus_personal.md
@@ -1,4 +1,3 @@
-<!--- Do not delete this line, it is needed for jinja_markdown to render this page correctly -->
 ## Set up [Globus Personal Connect](https://www.globus.org/globus-connect-personal)
 
 Your Globus account may grant you access to various Collections where you can access and transfer data.  You may also want to download directly to your own laptop.

--- a/web/portal/templates/doc/how_to_acknowledge.md
+++ b/web/portal/templates/doc/how_to_acknowledge.md
@@ -1,4 +1,3 @@
-
 ## How to Acknowledge
 
 ### DC2 Simulated Sky Survey

--- a/web/portal/templates/doc/install_gcr.md
+++ b/web/portal/templates/doc/install_gcr.md
@@ -1,4 +1,3 @@
-<!--- Do not delete this line, it is needed for jinja_markdown to render this page correctly -->
 ## Install and Configure `GCRCatalogs`
 
 You can install [`GCRCatalogs`](https://github.com/LSSTDESC/gcr-catalogs) with [conda](https://docs.conda.io/) or [pip](https://pip.pypa.io/),
@@ -12,11 +11,11 @@ Before installation, you may want to create a new conda environment.
 If you do,
 [see instructions here](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html).
 
-`GCRCatalogs` is available on [conda-forge](https://conda-forge.org/), not on conda's "defaults" channel. 
+`GCRCatalogs` is available on [conda-forge](https://conda-forge.org/), not on conda's "defaults" channel.
 If you are using the "defaults" channel (for example, if you haven't heard of conda-forge),
 you can still install `GCRCatalogs` directly using the instruction below.
-However, please consider switching to the conda-forge channel; 
-see [instructions](https://conda-forge.org/docs/user/introduction.html#how-can-i-install-packages-from-conda-forge) 
+However, please consider switching to the conda-forge channel;
+see [instructions](https://conda-forge.org/docs/user/introduction.html#how-can-i-install-packages-from-conda-forge)
 and [why](https://conda-forge.org/docs/user/tipsandtricks.html#using-multiple-channels).
 
 #### Install

--- a/web/portal/templates/doc/menu.md
+++ b/web/portal/templates/doc/menu.md
@@ -10,7 +10,7 @@
 #### Instructions and Notebooks Specific to Data Set
 
 * [DC2 Simulated Sky Survey]({{url_for('render_doc', doc_name='dc2_sim_sky_survey')}})
-* [cosmoDC2]({{url_for('render_doc', doc_name='cosmodc2')}})
+* [CosmoDC2]({{url_for('render_doc', doc_name='cosmodc2')}})
 
 #### Need Help?
 

--- a/web/portal/templates/doc/menu.md
+++ b/web/portal/templates/doc/menu.md
@@ -1,4 +1,3 @@
-
 ### Documentation
 
 #### General Instructions
@@ -8,11 +7,11 @@
 * [Install and configure `GCRCatalogs`]({{url_for('render_doc', doc_name='install_gcr')}})
 * [How to acknowledge]({{url_for('render_doc', doc_name='how_to_acknowledge')}})
 
-
 #### Instructions and Notebooks Specific to Data Set
 
 * [DC2 Simulated Sky Survey]({{url_for('render_doc', doc_name='dc2_sim_sky_survey')}})
 * [cosmoDC2]({{url_for('render_doc', doc_name='cosmodc2')}})
 
 #### Need Help?
+
 * [Post a question here!](https://github.com/LSSTDESC/desc-data-portal/discussions)

--- a/web/portal/templates/doc_template.jinja2
+++ b/web/portal/templates/doc_template.jinja2
@@ -6,9 +6,18 @@
 
 <div class="container">
 
-   {% markdown %}
-   {% include "doc/" + doc_name + ".md" %}
-   {% endmarkdown %}
+  <div class="row">
+    <div class="col-md-3">
+      {% markdown %}
+      {% include "doc/menu.md" %}
+      {% endmarkdown %}
+    </div>
+    <div class="col-md-9">
+      {% markdown %}
+      {% include "doc/" + doc_name + ".md" %}
+      {% endmarkdown %}
+    </div>
+  </div>
 
 </div>
 <!-- container -->

--- a/web/portal/templates/doc_template.jinja2
+++ b/web/portal/templates/doc_template.jinja2
@@ -6,19 +6,19 @@
 
 <div class="container">
 
-<div class="row">
-<div class="col-md-3">
+  <div class="row">
+    <div class="col-md-3">
+<!-- indentation for markdown removed below to make sure markdown display correctly -->
 {% markdown %}
 {%- include "doc/menu.md" -%}
 {% endmarkdown %}
-</div>
-
-<div class="col-md-9">
+    </div>
+    <div class="col-md-9">
 {% markdown %}
 {%- include "doc/" + doc_name + ".md" -%}
 {% endmarkdown %}
-</div>
-</div>
+    </div>
+  </div>
 
 </div>
 <!-- container -->

--- a/web/portal/templates/doc_template.jinja2
+++ b/web/portal/templates/doc_template.jinja2
@@ -6,18 +6,19 @@
 
 <div class="container">
 
-  <div class="row">
-    <div class="col-md-3">
-      {% markdown %}
-      {% include "doc/menu.md" %}
-      {% endmarkdown %}
-    </div>
-    <div class="col-md-9">
-      {% markdown %}
-      {% include "doc/" + doc_name + ".md" %}
-      {% endmarkdown %}
-    </div>
-  </div>
+<div class="row">
+<div class="col-md-3">
+{% markdown %}
+{%- include "doc/menu.md" -%}
+{% endmarkdown %}
+</div>
+
+<div class="col-md-9">
+{% markdown %}
+{%- include "doc/" + doc_name + ".md" -%}
+{% endmarkdown %}
+</div>
+</div>
 
 </div>
 <!-- container -->

--- a/web/portal/templates/home.jinja2
+++ b/web/portal/templates/home.jinja2
@@ -66,17 +66,18 @@
 
           <!--Grid column-->
           <div class="col-lg-6 col-md-12 px-4">
-            {% markdown %}
-            {% include "doc/getting_started.md" %}
-            {% endmarkdown %}
+<!-- indentation for markdown removed below to make sure markdown display correctly -->
+{% markdown %}
+{%- include "doc/getting_started.md" -%}
+{% endmarkdown %}
           </div>
           <!--/Grid column-->
 
           <!--Grid column-->
           <div class="col-lg-6 col-md-12 px-4">
-            {% markdown %}
-            {% include "doc/menu.md" %}
-            {% endmarkdown %}
+{% markdown %}
+{%- include "doc/menu.md" -%}
+{% endmarkdown %}
           </div>
           <!--/Grid column-->
 

--- a/web/portal/templates/transfer.jinja2
+++ b/web/portal/templates/transfer.jinja2
@@ -38,12 +38,8 @@
                   <tr>
                     <td class="col-md-5 text-left">
                       <i class="fa fa-folder fa-lg"></i>&nbsp;
-                      <a href="{{url_for('browse', dataset_id=dataset['id'])}}">
-                        {{dataset["name"]}}
-                      </a>
-                      {%if dataset['doc_name']%}
-                      (<a href="{{url_for('render_doc', doc_name=dataset['doc_name'])}}">doc</a>)
-                      {%endif%}
+                      <a href="{{url_for('browse', dataset_id=dataset['id'])}}">{{dataset["name"]}}</a>
+                      {%if dataset['doc_name']%}(<a href="{{url_for('render_doc', doc_name=dataset['doc_name'])}}">doc</a>){%endif%}
                     </td>
                     <td class="col-md-1 text-right">{{dataset['size']}}</td>
                     <td class="col-md-1 text-center">

--- a/web/portal/templates/transfer.jinja2
+++ b/web/portal/templates/transfer.jinja2
@@ -55,9 +55,8 @@
         <hr>
 
         <div class="row">
-          <div class="form-actions col-md-7 pull-right">
-            <input name="transfer" type="submit" class="btn btn-primary"
-                   value="Transfer">
+          <div class="col-md-12">
+            <input name="browse" type="submit" class="btn btn-primary block-center" value="Transfer">
           </div>
         </div>
         <div class="row">

--- a/web/portal/templates/transfer.jinja2
+++ b/web/portal/templates/transfer.jinja2
@@ -16,6 +16,9 @@
       <strong>or</strong>
       click on a dataset name to browse and choose individual files for transfer.
     </p>
+    <p>
+      To learn more about a dateset, click the "doc" link next to the dataset name.
+    </p>
 
     <div class="form-wrapper">
       <form class="form-inline" role="form" action="{{url_for('transfer')}}" method="post">
@@ -38,6 +41,9 @@
                       <a href="{{url_for('browse', dataset_id=dataset['id'])}}">
                         {{dataset["name"]}}
                       </a>
+                      {%if dataset['doc_name']%}
+                      (<a href="{{url_for('render_doc', doc_name=dataset['doc_name'])}}">doc</a>)
+                      {%endif%}
                     </td>
                     <td class="col-md-1 text-right">{{dataset['size']}}</td>
                     <td class="col-md-1 text-center">

--- a/web/portal/views.py
+++ b/web/portal/views.py
@@ -261,6 +261,7 @@ def browse(dataset_id=None, endpoint_id=None, endpoint_path=None):
                            myid=(dataset['id'] if dataset_id
                                         else None),
                            has_example_set=(dataset_id and 'example' in dataset),
+                           doc_name=(dataset.get("doc_name") if dataset_id else None),
                            file_list=file_list, webapp_xfer=webapp_xfer)
 
     if request.method == 'POST':


### PR DESCRIPTION
This PR improves the documentation navigation by
- Adding the doc menu as a left sidebar on documentation pages 
- Adding links to dataset docs on "Transfer" and "Browse Datasets" pages

This PR improves the dataset documentation content by
- Adding a one-sentence summary of the dataset nature at the very beginning
- Mentioning the original format, where to find information about partition and data schema. 
- Mentioning the potential issue of parquet on old machines
- Mentioning that, for cosmoDC2, the raw files may not contain the quantities in the schema. 

We should test this PR on the dev site to make sure the documentation navigation works correctly, and make any style adjustments as needed.

