### PR TITLE
adding patch applied to production portal after adding ANL endpoint

### DIFF
--- a/web/portal/views.py
+++ b/web/portal/views.py
@@ -17,7 +17,10 @@ except ImportError:
 
 @app.route('/', methods=['GET'])
 def home():
-    """Home page - play with it if you must!"""
+    if 'source_endpoint' in session:
+        pass
+    else:
+        session['source_endpoint'] = 1
     return render_template('home.jinja2')
 
 

--- a/web/portal/views.py
+++ b/web/portal/views.py
@@ -17,9 +17,7 @@ except ImportError:
 
 @app.route('/', methods=['GET'])
 def home():
-    if 'source_endpoint' in session:
-        pass
-    else:
+    if 'source_endpoint' not in session:
         session['source_endpoint'] = 1
     return render_template('home.jinja2')
 
@@ -433,5 +431,4 @@ def transfer_status(task_id):
     task = transfer.get_task(task_id)
 
     return render_template('transfer_status.jinja2', task=task)
-
 


### PR DESCRIPTION
Addressing #76 
Late back on Jan 19th, Katrin reported that the production portal returned an "Internal Server Error" when attempting to select a subset of the DC2 truth match files.  This was right after we had deployed the new version that included the ANL endpoint.  Given that Katrin was a previous user - I realized that the new source_endpoint session variable might be unset in her case.  I fixed that and deployed it to dev and then to prod.  Then things were working for Katrin again.
This PR is to bring that patch back into the repo.  
Yes, I feel extreme guilt for not doing that sooner.